### PR TITLE
Add tempo blocks

### DIFF
--- a/docs/beat.md
+++ b/docs/beat.md
@@ -1,0 +1,12 @@
+# Beat
+
+Converts a beat fraction into a number of milliseconds based on the current tempo.
+
+```sig
+music.beat(BeatFraction.Sixteenth)
+```
+
+## Parameters
+
+
+* **fraction**: the beat fraction to convert into milliseconds

--- a/docs/change-tempo-by.md
+++ b/docs/change-tempo-by.md
@@ -1,0 +1,12 @@
+# Change tempo by
+
+Changes the current tempo by the given bpm. Tempo cannot be set to a value lower than 0.1. This only affects the other tempo blocks in this extension, NOT the tempo of the currently playing music in Minecraft.
+
+```sig
+music.changeTempoBy(20)
+```
+
+## Parameters
+
+
+* **bpm**: the amount to change the current tempo by.

--- a/docs/pause.md
+++ b/docs/pause.md
@@ -1,0 +1,12 @@
+# Pause
+
+Pauses for the given amount of time.
+
+```sig
+music.pause(music.beat(BeatFraction.Sixteenth))
+```
+
+## Parameters
+
+
+* **millis**: the number of milliseconds to pause for

--- a/docs/play-note.md
+++ b/docs/play-note.md
@@ -3,7 +3,7 @@
 Play a music note from our note selector on different Minecraft-specified instruments.
 
 ```sig
-music.playNote(Note.C, Instrument.Chime)
+music.playNote(Note.C, Instrument.Chime, music.beat(BeatFraction.Sixteenth))
 ```
 
 This block uses the Minecraft `/playsound` command underneath to allow for all the users to hear the note on the specified instrument.
@@ -13,3 +13,4 @@ This block uses the Minecraft `/playsound` command underneath to allow for all t
 
 * **note**: the frequency to be played
 * **instrument**: the musical instrument that the frequency will be played on
+* **millis**: the number of milliseconds to pause after playing the note

--- a/docs/play-sound.md
+++ b/docs/play-sound.md
@@ -3,7 +3,7 @@
 Play mob and item sounds to create cool rhythms from a blaze to a villager haggle!
 
 ```sig
-music.playSound(Sound.Blaze)
+music.playSound(Sound.Blaze, music.beat(BeatFraction.Sixteenth))
 ```
 
 This block uses the Minecraft `/playsound` command underneath to allow for all the users to hear the sound.
@@ -12,3 +12,4 @@ This block uses the Minecraft `/playsound` command underneath to allow for all t
 
 
 * **sound**: the sound to be played in the game, specifically sounds that comes from popular mobs and game sound effects
+* **millis**: the number of milliseconds to pause after playing the note

--- a/docs/set-tempo.md
+++ b/docs/set-tempo.md
@@ -1,0 +1,12 @@
+# Set tempo
+
+Sets the current tempo to the given beats per minute (BPM). Tempo cannot be set to a value lower than 0.1. This only affects the other tempo blocks in this extension, NOT the tempo of the currently playing music in Minecraft.
+
+```sig
+music.setTempo(120)
+```
+
+## Parameters
+
+
+* **bpm**: the beats per minute (BPM) to set the tempo to

--- a/docs/tempo.md
+++ b/docs/tempo.md
@@ -1,0 +1,7 @@
+# Tempo
+
+Returns the current tempo in beats per minute (BPM). This is the tempo used by other blocks in this extension, NOT the tempo of the currently playing music in Minecraft.
+
+```sig
+music.tempo()
+```

--- a/pxt.json
+++ b/pxt.json
@@ -7,11 +7,21 @@
         "builder": "*"
     },
     "files": [
+        "docs/beat.md",
+        "docs/change-tempo-by.md",
+        "docs/pause.md",
+        "docs/play-disc.md",
+        "docs/play-note.md",
+        "docs/play-sound.md",
+        "docs/set-tempo.md",
+        "docs/tempo.md",
+        "docs/volume.md",
         "src/instrument.ts",
         "src/music.ts",
         "src/note.ts",
         "src/sound.ts",
         "src/volume.ts",
+        "src/tempo.ts",
         "README.md"
     ],
     "testFiles": [

--- a/src/note.ts
+++ b/src/note.ts
@@ -70,15 +70,22 @@ namespace music {
      * @param instrument instrument to play the note as
      */
     //% group="Notes"
-    //% weight=90 blockGap=8
-    //% blockId=minecraft_music_play_note block="play|note $note|on $instrument"
-    //% note.shadow="minecraft_note_frequency"
-    //% instrument.shadow="minecraft_instrument"
+    //% weight=90
+    //% blockGap=8
+    //% blockId=minecraft_music_play_note
+    //% block="play|note $note|on $instrument||and pause for $millis"
+    //% note.shadow=minecraft_note_frequency
+    //% instrument.shadow=minecraft_instrument
+    //% millis.shadow=sound_beat
     //% help=github:makecode-minecraft-music/docs/play-note
-    export function playNote(note: number, instrument: number): void {
+    export function playNote(note: number, instrument: number, millis?: number): void {
         const soundId: string = _instrumentMinecraftId(instrument);
         const pitch: string = _frequencyToMinecraftPitch(note);
         player.execute(`playsound ${soundId} @a ~ ~ ~ ${music.volumeInGameUnits} ${pitch}`)
+
+        if (millis > 0) {
+            loops.pause(millis);
+        }
     }
 
     /**

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -77,13 +77,18 @@ namespace music {
      * @param sound the sound to play, eg: Sound.Blaze
      */
     //% weight=90
-    //% blockId=sound_play_sound block="play|sound $sound" blockGap=8
+    //% blockId=sound_play_sound block="play|sound $sound||and pause for $millis" blockGap=8
+    //% millis.shadow=sound_beat
     //% parts="headphone"
     //% useEnumVal=1
     //% group="Sound"
     //% help=github:makecode-minecraft-music/docs/play-sound
-    export function playSound(sound: Sound): void {
+    export function playSound(sound: Sound, millis?: number): void {
         player.execute(`playsound ${minecraftSoundId(sound)} @a ~ ~ ~ ${music.volumeInGameUnits}`)
+
+        if (millis > 0) {
+            loops.pause(millis);
+        }
     }
 
     function minecraftSoundId(sound: Sound) {

--- a/src/tempo.ts
+++ b/src/tempo.ts
@@ -1,0 +1,110 @@
+enum BeatFraction {
+    //% block=1
+    Whole = 1,
+    //% block="1/2"
+    Half = 2,
+    //% block="1/4"
+    Quarter = 4,
+    //% block="1/8"
+    Eighth = 8,
+    //% block="1/16"
+    Sixteenth = 16,
+    //% block="2"
+    Double = 32,
+    //% block="4",
+    Breve = 64
+}
+
+namespace music {
+    export let beatsPerMinute = 120;
+
+    /**
+     * Returns the duration of a beat in milliseconds
+     */
+    //% blockId=sound_beat
+    //% block="$fraction|beat"
+    //% group="Tempo"
+    //% weight=49
+    //% blockGap=8
+    export function beat(fraction?: BeatFraction): number {
+        if (fraction == null) fraction = BeatFraction.Whole;
+        let beat = 60000 / Math.max(beatsPerMinute, 0.1);
+        switch (fraction) {
+            case BeatFraction.Half: return Math.round(beat / 2);
+            case BeatFraction.Quarter: return Math.round(beat / 4);
+            case BeatFraction.Eighth: return Math.round(beat / 8);
+            case BeatFraction.Sixteenth: return Math.round(beat / 16);
+            case BeatFraction.Double: return Math.round(beat * 2);
+            case BeatFraction.Breve: return Math.round(beat * 4);
+            default: return Math.round(beat);
+        }
+    }
+
+    /**
+     * Returns the tempo in beats per minute. This is the tempo use by blocks in this extension, NOT the tempo of the currently playing music in Minecraft.
+     *
+     * Tempo is the speed (bpm = beats per minute) at which notes play. The larger the tempo value, the faster the notes will play.
+     */
+    //% help=github:makecode-minecraft-music/docs/tempo
+    //% blockId=sound_tempo
+    //% block="tempo (bpm)"
+    //% group="Tempo"
+    //% weight=40
+    //% blockGap=8
+    export function tempo(): number {
+        return beatsPerMinute;
+    }
+
+    /**
+     * Change the tempo by the specified amount. This only affects the other tempo blocks in this extension, NOT the tempo of the currently
+     * playing music in Minecraft.
+     *
+     * @param bpm The change in beats per minute to the tempo, eg: 20
+     */
+    //% help=github:makecode-minecraft-music/docs/change-tempo-by
+    //% blockId=sound_change_tempo
+    //% block="change tempo by (bpm)|$bpm"
+    //% bpm.defl=20
+    //% group="Tempo"
+    //% weight=39
+    //% blockGap=8
+    export function changeTempoBy(bpm: number): void {
+        setTempo(beatsPerMinute + bpm);
+    }
+
+    /**
+     * Sets the tempo to the specified amount. This only affects the other tempo blocks in this extension, NOT the tempo of the currently
+     * playing music in Minecraft.
+     *
+     * @param bpm The new tempo in beats per minute
+     */
+    //% help=github:makecode-minecraft-music/docs/set-tempo
+    //% blockId=sound_set_tempo
+    //% block="set tempo to (bpm)|$bpm"
+    //% bpm.defl=120
+    //% bpm.min=4
+    //% bpm.max=1000
+    //% group="Tempo"
+    //% weight=38
+    //% blockGap=8
+    export function setTempo(bpm: number): void {
+        if (isNaN(bpm)) return;
+        if (bpm > 0) {
+            beatsPerMinute = Math.max(0.1, bpm);
+        }
+    }
+
+    /**
+     * Pauses for the given amount of time
+     * @param millis The time to pause in milliseconds
+     */
+    //% help=github:makecode-minecraft-music/docs/pause
+    //% blockId=sound_rest
+    //% block="pause for $millis"
+    //% millis.shadow=sound_beat
+    //% group="Tempo"
+    //% weight=37
+    export function pause(millis: number): void {
+        loops.pause(millis)
+    }
+}


### PR DESCRIPTION
Adds tempo blocks:

![image](https://github.com/microsoft/makecode-minecraft-music/assets/13754588/4cb6b22e-e5fc-4e40-bdc4-2d7d210c52fb)

Also tweaks the play note/sound blocks so that they can optionally pause based on the current tempo:

![expand-block](https://github.com/microsoft/makecode-minecraft-music/assets/13754588/7490a626-af15-487f-a757-6a303672a686)

The motivation here is that it's currently difficult to compose music using these blocks when they don't pause; You have to pause on your own and also figure out the right number of milliseconds for the tempo you're going for.

My one hesitation here is that I'm worried kids will think that they can change the tempo of currently playing songs in minecraft, which this does not do. I tried to make that clear in all of the JSdoc and documentation.

@Jaqster FYI