### PR TITLE
block category changed color, moved above loops

### DIFF
--- a/src/music.ts
+++ b/src/music.ts
@@ -29,7 +29,7 @@ declare const enum MusicDisc {
     Pigstep
 }
 
-//% color=#E30FC0 weight=70 icon="\uf025"
+//% color=#E30FC0 weight=55 icon="\uf025"
 //% groups='["Music Discs", "Sound", "Notes", "Volume"]'
 namespace music {
     /**

--- a/src/music.ts
+++ b/src/music.ts
@@ -29,7 +29,7 @@ declare const enum MusicDisc {
     Pigstep
 }
 
-//% color=#E63022 weight=40 icon="\uf025"
+//% color=#E30FC0 weight=70 icon="\uf025"
 //% groups='["Music Discs", "Sound", "Notes", "Volume"]'
 namespace music {
     /**


### PR DESCRIPTION
Changed the music category to be the same color as the music category in arcade. Music extension will now be above the loops category.

<img width="85" alt="image" src="https://github.com/microsoft/makecode-minecraft-music/assets/49178322/3686a7ff-c3d6-4759-8457-7cfcdbeb1592">

Fixes https://github.com/microsoft/pxt-minecraft/issues/2374
Fixes https://github.com/microsoft/makecode-minecraft-music/issues/6