### PR TITLE
Changed order of block groups as suggested

### DIFF
--- a/src/music.ts
+++ b/src/music.ts
@@ -30,7 +30,7 @@ declare const enum MusicDisc {
 }
 
 //% color=#E30FC0 weight=55 icon="\uf025"
-//% groups='["Music Discs", "Sound", "Notes", "Volume"]'
+//% groups='["Notes",  "Sound", "Music Discs", "Volume"]'
 namespace music {
     /**
      * Play a Minecraft music disc.

--- a/src/music.ts
+++ b/src/music.ts
@@ -30,7 +30,7 @@ declare const enum MusicDisc {
 }
 
 //% color=#E30FC0 weight=55 icon="\uf025"
-//% groups='["Notes",  "Sound", "Music Discs", "Volume"]'
+//% groups='["Notes", "Sound", "Music Discs", "Volume"]'
 namespace music {
     /**
      * Play a Minecraft music disc.


### PR DESCRIPTION
The blocks now go
Notes, Sounds, Music discs, Volume, Tempo

<img width="213" alt="image" src="https://github.com/microsoft/makecode-minecraft-music/assets/49178322/210cfa04-67d3-440a-92b5-2cccc05ada16">

Fixes https://github.com/microsoft/makecode-minecraft-music/issues/8