### PR TITLE
Add relic, 5 music discs

### DIFF
--- a/src/music.ts
+++ b/src/music.ts
@@ -26,7 +26,9 @@ declare const enum MusicDisc {
     //% block="Lena Raine - otherside"
     Otherside,
     //% block="Lena Raine - Pigstep"
-    Pigstep
+    Pigstep,
+    //% block="Aaron Cherof - Relic"
+    Relic
 }
 
 //% color=#E30FC0 weight=55 icon="\uf025"
@@ -59,6 +61,7 @@ namespace music {
             case MusicDisc.Ward: return "record.ward";
             case MusicDisc.Otherside: return "record.otherside";
             case MusicDisc.Pigstep: return "record.pigstep";
+            case MusicDisc.Relic: return "record.relic";
             default: throw `Unrecognized MusicDisc enum value: ${musicDisc}`;
         }
     }

--- a/src/music.ts
+++ b/src/music.ts
@@ -28,7 +28,9 @@ declare const enum MusicDisc {
     //% block="Lena Raine - Pigstep"
     Pigstep,
     //% block="Aaron Cherof - Relic"
-    Relic
+    Relic,
+    //% block="Samuel Aberg - 5"
+    Five
 }
 
 //% color=#E30FC0 weight=55 icon="\uf025"
@@ -49,6 +51,7 @@ namespace music {
         switch (musicDisc) {
             case MusicDisc.Eleven: return "record.11";
             case MusicDisc.Thirteen: return "record.13";
+            case MusicDisc.Five: return "record.5"
             case MusicDisc.Blocks: return "record.blocks";
             case MusicDisc.Cat: return "record.cat";
             case MusicDisc.Chirp: return "record.chirp";


### PR DESCRIPTION
Thanks, @thsparks for pointing this out! When doing this work, I also noticed we were missing the record '5', so I added it into the enum as well. 

One thing I noticed is that if you try to run the `relic` disc in a version of Minecraft that is not 1.20 or greater, it will fail silently. I'm not sure how large the chunk of users would be that wouldn't be running the latest version of Minecraft, but it might be something that we want check on in the future. This might just be something we see in user testing, but this also might be avoidable with versioned commands which I think we are working on for this release.

Fixes https://github.com/microsoft/makecode-minecraft-music/issues/7