### PR TITLE
Note and sound blocks will now pause if block collapsed

### DIFF
--- a/src/note.ts
+++ b/src/note.ts
@@ -83,6 +83,11 @@ namespace music {
         const pitch: string = _frequencyToMinecraftPitch(note);
         player.execute(`playsound ${soundId} @a ~ ~ ~ ${music.volumeInGameUnits} ${pitch}`)
 
+        // use == here to check for null and undefined
+        if (millis == undefined) {
+            loops.pause(beat(BeatFraction.Whole));
+        }
+
         if (millis > 0) {
             loops.pause(millis);
         }

--- a/src/note.ts
+++ b/src/note.ts
@@ -85,7 +85,7 @@ namespace music {
 
         // use == here to check for null and undefined
         if (millis == undefined) {
-            loops.pause(beat(BeatFraction.Whole));
+            millis = beat(BeatFraction.Whole);
         }
 
         if (millis > 0) {

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -88,7 +88,7 @@ namespace music {
 
         // use == here to check for null and undefined
         if (millis == undefined) {
-            loops.pause(beat(BeatFraction.Whole));
+            millis = beat(BeatFraction.Whole);
         }
 
         if (millis > 0) {

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -86,6 +86,11 @@ namespace music {
     export function playSound(sound: Sound, millis?: number): void {
         player.execute(`playsound ${minecraftSoundId(sound)} @a ~ ~ ~ ${music.volumeInGameUnits}`)
 
+        // use == here to check for null and undefined
+        if (millis == undefined) {
+            loops.pause(beat(BeatFraction.Whole));
+        }
+
         if (millis > 0) {
             loops.pause(millis);
         }


### PR DESCRIPTION
Before, if the sound and note blocks were not expanded, the sounds/notes would just play on top of each other without pausing. This functionality is a bit funky, so now the blocks will always pause for 1 beat by default. 

Fixes https://github.com/microsoft/makecode-minecraft-music/issues/12