### PR TITLE
Added position to play music disc block

### DIFF
--- a/src/music.ts
+++ b/src/music.ts
@@ -41,10 +41,12 @@ namespace music {
      * @param builtInMusicDisc a built-in Minecraft music disc you wish to play
      */
     //% group="Music Discs" weight=60
-    //% block="play music disc $builtInMusicDisc"
+    //% block="play music disc $builtInMusicDisc ||at $position"
+    //% position.shadow=minecraftCreatePositionCamera
     //% help=github:makecode-minecraft-music/docs/play-disc
-    export function playMusic(builtInMusicDisc: MusicDisc): void {
-        player.execute(`playsound ${minecraftTrackName(builtInMusicDisc)} @a ~ ~ ~ ${music.volumeInGameUnits}`);
+    export function playMusic(builtInMusicDisc: MusicDisc, position?: Position): void {
+        const positionString = position ? position.toString() : "~ ~ ~";
+        player.execute(`playsound ${minecraftTrackName(builtInMusicDisc)} @a ${positionString} ${music.volumeInGameUnits}`);
     }
 
     function minecraftTrackName(musicDisc: MusicDisc) {


### PR DESCRIPTION
The command that we use underneath for these blocks, `playsound` , takes a position. For notes and sounds, there's no problem for having one source point because their sounds are short enough and it just sounds like it's always around the player. However, for music discs, because they are much longer, playing a disc and then walking around is a bit confusing because the music doesn't follow the player, it is only coming from where the player was when they ran the command. Because we want to make this a bit more explicit, the position has been added as an expandable parameter. By default, the block will be placed at where the player is. 

<img width="496" alt="image" src="https://github.com/microsoft/makecode-minecraft-music/assets/49178322/d124c75d-5a4b-4223-bf09-528837d723b8">

Fixes https://github.com/microsoft/makecode-minecraft-music/issues/9
