### PR TITLE
Added the `in background` label to music discs

### DIFF
--- a/src/music.ts
+++ b/src/music.ts
@@ -41,7 +41,7 @@ namespace music {
      * @param builtInMusicDisc a built-in Minecraft music disc you wish to play
      */
     //% group="Music Discs" weight=60
-    //% block="play music disc $builtInMusicDisc ||at $position"
+    //% block="play music disc $builtInMusicDisc in background ||at $position"
     //% position.shadow=minecraftCreatePositionCamera
     //% help=github:makecode-minecraft-music/docs/play-disc
     export function playMusic(builtInMusicDisc: MusicDisc, position?: Position): void {


### PR DESCRIPTION
The play music disc block now has the `in background` descriptor so that it follows closer conventions to our other music playing blocks in the other editors. 

<img width="373" alt="image" src="https://github.com/microsoft/makecode-minecraft-music/assets/49178322/9ef5f826-ad1c-4018-aa6c-6d1828dd9087">

Fixes https://github.com/microsoft/makecode-minecraft-music/issues/11