### PR TITLE
Change name of extension in pxt.json

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -1,7 +1,7 @@
 {
-    "name": "music",
-    "description": "Sound and Music",
-    "version": "0.0.5",
+    "name": "makecode-minecraft-music",
+    "description": "Play Minecraft music discs, make music with notes, and make sounds from mobs!",
+    "version": "0.0.6",
     "dependencies": {
         "core": "*",
         "builder": "*"


### PR DESCRIPTION
Because the name that I used in `pxt.json` was different from the repo name, the docs for the extension weren't working. This fix should address this. I also updated the description to give a bit more detail.

Hopeful that this will address the problems found here https://github.com/microsoft/pxt-minecraft/issues/2448. If so, I'll make these changes in the other repos as well.