### PR TITLE
Fixed problem with sound doc

### DIFF
--- a/docs/play-sound.md
+++ b/docs/play-sound.md
@@ -1,4 +1,4 @@
-# play a Music Disc
+# play a Minecraft Sound
 
 Play mob and item sounds to create cool rhythms from a blaze to a villager haggle!
 


### PR DESCRIPTION
With the music docs now working, I noticed that there's a problem with the docs for `play sound`. The title had `play a music disc` when it should be `play a sound` or something similar. 